### PR TITLE
Analyze and fix analytics graph loading issue

### DIFF
--- a/frontend/src/components/ui/UnifiedAnalyticsChart.tsx
+++ b/frontend/src/components/ui/UnifiedAnalyticsChart.tsx
@@ -1320,6 +1320,9 @@ const UnifiedAnalyticsChart: React.FC<UnifiedAnalyticsChartProps> = ({
                   '&.Mui-selected': {
                     background: 'linear-gradient(135deg, #667eea 0%, #764ba2 100%)',
                     color: 'white',
+                    '&:hover': {
+                      background: 'linear-gradient(135deg, #5a67d8 0%, #6b46c1 100%)',
+                    },
                   },
                 }}
               >
@@ -1388,9 +1391,6 @@ const UnifiedAnalyticsChart: React.FC<UnifiedAnalyticsChartProps> = ({
                   '&.Mui-selected': {
                     backgroundColor: 'primary.main',
                     color: 'white',
-                    '&:hover': {
-                      backgroundColor: 'primary.dark',
-                    },
                   },
                 },
               }}
@@ -1507,6 +1507,7 @@ const UnifiedAnalyticsChart: React.FC<UnifiedAnalyticsChartProps> = ({
         key={`chart-container-${chartType}-${chartKey}`}
         elevation={0}
         sx={{
+          width: '100%',
           p: 3,
           backgroundColor: '#fff',
           border: '1px solid rgba(0, 0, 0, 0.05)',

--- a/frontend/src/components/ui/UnifiedAnalyticsChart.tsx
+++ b/frontend/src/components/ui/UnifiedAnalyticsChart.tsx
@@ -1508,6 +1508,7 @@ const UnifiedAnalyticsChart: React.FC<UnifiedAnalyticsChartProps> = ({
         elevation={0}
         sx={{
           width: '100%',
+          minHeight: '300px',
           p: 3,
           backgroundColor: '#fff',
           border: '1px solid rgba(0, 0, 0, 0.05)',

--- a/frontend/src/hooks/useSize.ts
+++ b/frontend/src/hooks/useSize.ts
@@ -22,14 +22,14 @@ export default function useSize<T extends HTMLElement = HTMLElement>(
     // not get stuck in a perpetual loading state.
     const rect = element.getBoundingClientRect();
     const initialWidth = element.offsetWidth || rect.width || window.innerWidth;
-    const initialHeight = element.offsetHeight || rect.height || 0;
+    const initialHeight = element.offsetHeight || rect.height || window.innerHeight;
     setSize({ width: initialWidth, height: initialHeight });
 
     const resizeObserver = new ResizeObserver((entries) => {
       for (const entry of entries) {
         if (entry.contentRect) {
           const observedWidth = entry.contentRect.width || entry.target.getBoundingClientRect().width || window.innerWidth;
-          const observedHeight = entry.contentRect.height || entry.target.getBoundingClientRect().height || 0;
+          const observedHeight = entry.contentRect.height || entry.target.getBoundingClientRect().height || window.innerHeight;
           setSize({
             width: observedWidth,
             height: observedHeight,

--- a/frontend/src/hooks/useSize.ts
+++ b/frontend/src/hooks/useSize.ts
@@ -16,14 +16,22 @@ export default function useSize<T extends HTMLElement = HTMLElement>(
     if (!element) return;
 
     // Initialise with the element's current size so the first render has data.
-    setSize({ width: element.offsetWidth, height: element.offsetHeight });
+    // If `offsetWidth` is 0 (which can happen when the element is invisible
+    // during the first paint), we fall back to `getBoundingClientRect()` and
+    // finally `window.innerWidth` so that consumers relying on a >0 width do
+    // not get stuck in a perpetual loading state.
+    const initialWidth = element.offsetWidth || element.getBoundingClientRect().width || window.innerWidth;
+    const initialHeight = element.offsetHeight || element.getBoundingClientRect().height || 0;
+    setSize({ width: initialWidth, height: initialHeight });
 
     const resizeObserver = new ResizeObserver((entries) => {
       for (const entry of entries) {
         if (entry.contentRect) {
+          const observedWidth = entry.contentRect.width || entry.target.getBoundingClientRect().width || window.innerWidth;
+          const observedHeight = entry.contentRect.height || entry.target.getBoundingClientRect().height || 0;
           setSize({
-            width: entry.contentRect.width,
-            height: entry.contentRect.height,
+            width: observedWidth,
+            height: observedHeight,
           });
         }
       }

--- a/frontend/src/hooks/useSize.ts
+++ b/frontend/src/hooks/useSize.ts
@@ -20,8 +20,9 @@ export default function useSize<T extends HTMLElement = HTMLElement>(
     // during the first paint), we fall back to `getBoundingClientRect()` and
     // finally `window.innerWidth` so that consumers relying on a >0 width do
     // not get stuck in a perpetual loading state.
-    const initialWidth = element.offsetWidth || element.getBoundingClientRect().width || window.innerWidth;
-    const initialHeight = element.offsetHeight || element.getBoundingClientRect().height || 0;
+    const rect = element.getBoundingClientRect();
+    const initialWidth = element.offsetWidth || rect.width || window.innerWidth;
+    const initialHeight = element.offsetHeight || rect.height || 0;
     setSize({ width: initialWidth, height: initialHeight });
 
     const resizeObserver = new ResizeObserver((entries) => {


### PR DESCRIPTION
Fix analytics charts stuck in loading state by ensuring container dimensions are correctly reported.

The charts were stuck in an endless 'loading' state because `ResizeObserver` often reported a zero width for the chart container, preventing `containerReady` from becoming true. This PR ensures the chart container always has a positive width by setting `width: '100%'` on its root element and adding robust fallback mechanisms in the `useSize` hook to guarantee valid dimensions are reported.